### PR TITLE
Make GET endpoints public and add CD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,6 @@ build/*
 node_modules
 .DS_Store
 
-# AWS Lambda credentials
-config/development.env
-config/qa.env
-config/production.env
 sam-template.development.yml
 sam-template.qa.yml
 sam-template.production.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ deploy:
     branch: development
 - provider: script
   skip_cleanup: true
+  script: npm run deploy-qa
+  on:
+    branch: qa
+- provider: script
+  skip_cleanup: true
   script: npm run deploy-production
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: node_js
+node_js:
+- '6'
+cache:
+  directories:
+  - node_modules
+install: npm install
+before_script: echo 'Running unit tests'
+script: npm test
+before_deploy: echo 'All unit tests passed; Preparing to deploy to AWS'
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: npm run deploy-development
+  on:
+    branch: development
+- provider: script
+  skip_cleanup: true
+  script: npm run deploy-production
+  on:
+    branch: master
+after_deploy: echo 'Successfully deployed to AWS'
+env:
+  global:
+    secure: Uy2FPBzr/6gbeAuXmSXohN4KBjxLBfTXGWLCu6yLgvwpTTEJyODJ8j1x+ztG2jFxpL454yXrlHGz6j53/SG4c+KPIVQ0YM3u+OTS9J/e9VProRcm2eGnv7pPm+3ZwdmSijxidI2RJU4RrDTnvC0Vd6IK3W4lk/RuzYCtQlluynXQCz0vqn2DlXSZmjty6PMVTDBAPYHMLrb8dnDEy1T1yZ9X/Sw88FA/AHXB8E9qgq3rp49F0QnHhWmSmcQ3sNnr2KOkyVMUdz8kZ0Qw8Yi0fUQedxmstnqfYTZjYMpu7F8kOpjAUo/3OxN4/yffWpSdXX/2KNVriq2tAzZPIyAsGCA/TrMTpEjOOXlvl2kZxNTh12opzvT2kPrpoE7HiCWKIWxfkVkfsuJSUDKZXV5y40cKTXVc3sM5y5mIX/nOPiqLmlE6WqHovvDjiv0rodK8b3VeQJmDxsmyRqSnNhMR6BbUZdBoIICYk6pMqDTe4ywxFI7GybzU9wKshvDfKkW3C2IbTXJTxbRlrsT9pRezJU62O96RJ8q3d3vPt7ky5g5WZyegYkaQLsUuXbQ9LnUkpdVyktixRkd82H+3aj3/RvX3kdyKGVvulM0yqfA4rKNTF0su8WgQ20VEbb9cc5B/58b9iat57q1ZlgaGeV6/M0oZpHmQ/B6ZH3QBpnvIm+s=

--- a/README.md
+++ b/README.md
@@ -69,15 +69,8 @@ The above was generated from `sam local generate-event api --method GET > sample
 
 ### Deploy
 
-We use `node-lambda` for deploy, so make sure you have a .env file with deployable variables in `./config/[environment].env`, e.g.
+This repo is configured to use Travis with `node-lambda` for continuous deployments. Environment variables are set for each environment from configuration files: `./config/[environment].env`.
 
-`cp config/sample.env config/development.env`
+Travis will automatically deploy on passing builds from the `development`, `qa`, and `master` branches to the corresponding environments.
 
-Development:
-`npm run deploy-development`
-
-QA:
-`npm run deploy-qa`
-
-Prod:
-`npm run deploy-production`
+To deploy locally for testing purposes, you can also use the corresponding NPM command: `npm run deploy-[environment]-local`.

--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ app.get('/api/v0.1/book-lists/:type/:date', (req, res) => {
       res.json(data)
     })
   })
-  .catch((e) => handleError(e, req, res))
+    .catch((e) => handleError(e, req, res))
 })
 
 /**
@@ -57,7 +57,7 @@ app.get('/api/v0.1/book-lists', (req, res) => {
         res.json(data)
       })
   })
-  .catch((e) => handleError(e, req, res))
+    .catch((e) => handleError(e, req, res))
 })
 
 /**
@@ -74,7 +74,7 @@ app.post('/api/v0.1/book-lists', (req, res) => {
     data['@context'] = `${app.baseUrl}/context.json`
     res.json(data)
   })
-  .catch((e) => handleError(e, req, res))
+    .catch((e) => handleError(e, req, res))
 })
 
 /**

--- a/config/development.env
+++ b/config/development.env
@@ -1,2 +1,2 @@
-BOOK_LISTS_BUCKET=book-lists
+BOOK_LISTS_BUCKET=book-lists-development
 VALID_BOOK_LIST_TYPES=staff-picks,teens,kids

--- a/config/development.env
+++ b/config/development.env
@@ -1,0 +1,2 @@
+BOOK_LISTS_BUCKET=book-lists
+VALID_BOOK_LIST_TYPES=staff-picks,teens,kids

--- a/config/production.env
+++ b/config/production.env
@@ -1,0 +1,2 @@
+BOOK_LISTS_BUCKET=book-lists
+VALID_BOOK_LIST_TYPES=staff-picks,teens,kids

--- a/config/production.env
+++ b/config/production.env
@@ -1,2 +1,2 @@
-BOOK_LISTS_BUCKET=book-lists
+BOOK_LISTS_BUCKET=book-lists-production
 VALID_BOOK_LIST_TYPES=staff-picks,teens,kids

--- a/config/qa.env
+++ b/config/qa.env
@@ -1,2 +1,2 @@
-BOOK_LISTS_BUCKET=book-lists
+BOOK_LISTS_BUCKET=book-lists-qa
 VALID_BOOK_LIST_TYPES=staff-picks,teens,kids

--- a/config/qa.env
+++ b/config/qa.env
@@ -1,0 +1,2 @@
+BOOK_LISTS_BUCKET=book-lists
+VALID_BOOK_LIST_TYPES=staff-picks,teens,kids

--- a/config/sample.env
+++ b/config/sample.env
@@ -1,2 +1,0 @@
-BOOK_LISTS_BUCKET=book-lists
-VALID_BOOK_LIST_TYPES=staff-picks,teens,kids

--- a/lib/book-list.js
+++ b/lib/book-list.js
@@ -2,7 +2,6 @@ const errors = require('./errors')
 const config = require('./config')
 
 class BookList {
-
   asJson () {
     let hash = this
     return hash

--- a/lib/list-store.js
+++ b/lib/list-store.js
@@ -37,7 +37,7 @@ const saveList = (list) => {
 const getList = (slug, options = {}) => {
   options = Object.assign({
     parseJson: true, // By default we parse json
-                    // Set to false to return raw string unparsed
+    // Set to false to return raw string unparsed
     cache: true
   }, options)
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -61,7 +61,7 @@ let logger = {
 }
 
 // Overwrite no-op logging functions above based on `logLevel`
-; LEVELS.forEach((level) => {
+LEVELS.forEach((level) => {
   if (LEVELS.indexOf(logLevel) >= LEVELS.indexOf(level)) {
     logger[level] = (message, meta) => _log(level.toUpperCase(), message, meta)
   }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "description": "A simple CRUD service on BookLists",
   "main": "index.js",
   "scripts": {
-    "deploy-development": "./node_modules/.bin/node-lambda deploy -e development -f ./config/development.env -b subnet-f4fe56af -g sg-1d544067 --role arn:aws:iam::224280085904:role/lambda_basic_execution --profile nypl-sandbox",
+    "deploy-development": "./node_modules/.bin/node-lambda deploy -e development -f ./config/development.env -o arn:aws:iam::224280085904:role/lambda_basic_execution -a $aws_access_key_id_development -s $aws_secret_access_key_development",
+    "deploy-development-local": "./node_modules/.bin/node-lambda deploy -e development -f ./config/development.env -g sg-1d544067 --role arn:aws:iam::224280085904:role/lambda_basic_execution --profile nypl-sandbox",
+    "deploy-qa": "./node_modules/.bin/node-lambda deploy -e qa -f ./config/qa.env -o arn:aws:iam::946183545209:role/lambda-full-access -a $aws_access_key_id_qa -s $aws_secret_access_key_qa",
+    "deploy-qa-local": "./node_modules/.bin/node-lambda deploy -e qa -f ./config/qa.env -g sg-116eeb60 --role arn:aws:iam::946183545209:role/lambda-full-access --profile nypl-digital-dev",
+    "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f ./config/production.env -o arn:aws:iam::946183545209:role/lambda-full-access -a $aws_access_key_id_production -s $aws_secret_access_key_production",
+    "deploy-production-local": "./node_modules/.bin/node-lambda deploy -e production -f ./config/production.env -g sg-116eeb60 --role arn:aws:iam::946183545209:role/lambda-full-access --profile nypl-digital-dev",
     "run-development": "sam local start-api --port 3001 --profile nypl-sandbox --template ./sam-template.development.yml",
-    "deploy-qa": "./node_modules/.bin/node-lambda deploy -e qa -f ./config/qa.env -b subnet-59bcdd03,subnet-5deecd15 -g sg-116eeb60 --role arn:aws:iam::946183545209:role/lambda-full-access --profile nypl-digital-dev",
     "run-qa": "sam local start-api --port 3001 --profile nypl-digital-dev --template ./sam-template.qa.yml",
-    "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f ./config/production.env -b subnet-59bcdd03,subnet-5deecd15 -g sg-116eeb60 --role arn:aws:iam::946183545209:role/lambda-full-access --profile nypl-digital-dev",
     "run-production": "sam local start-api --port 3001 --profile nypl-digital-dev --template ./sam-template.production.yml",
     "test": "./node_modules/.bin/standard --env mocha --globals expect && NODE_ENV=test ./node_modules/.bin/mocha test"
   },
@@ -35,8 +38,9 @@
     "chai": "^4.1.2",
     "chia": "0.0.1",
     "lambda-tester": "^3.1.0",
-    "mocha": "^4.0.1",
-    "node-lambda": "^0.11.4"
+    "mocha": "^4.1.0",
+    "node-lambda": "^0.11.4",
+    "standard": "^11.0.1"
   },
   "standard": {
     "globals": [

--- a/swagger.v0.1.json
+++ b/swagger.v0.1.json
@@ -53,14 +53,7 @@
           "500": {
             "description": "Error message in JSON format"
           }
-        },
-        "security": [
-          {
-            "api_auth": [
-              "read:book_list"
-            ]
-          }
-        ]
+        }
       }
     },
     "/v0.1/book-lists": {
@@ -114,14 +107,7 @@
           "500": {
             "description": "Error message in JSON format"
           }
-        },
-        "security": [
-          {
-            "api_auth": [
-              "read:book_list"
-            ]
-          }
-        ]
+        }
       },
       "post": {
         "tags": [

--- a/test/lambda.test.js
+++ b/test/lambda.test.js
@@ -10,6 +10,10 @@ process.on('SIGTSTP', exitHandler.bind(null, { exit: true })) // ctrl+v event
 process.on('uncaughtException', exitHandler.bind(null, { exit: true }))
 
 describe('Lambda index handler', function () {
+  after(function () {
+    exitHandler({ cleanup: true })
+  })
+
   it('should respond with 200 if path valid', function () {
     return LambdaTester(handler)
       .event({

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -21,7 +21,7 @@ before(function () {
     try {
       let localPath = path.join('./test/data/getObject', params.Key)
       let content = fs.readFileSync(localPath)
-      callback(null, { Body: new Buffer(content) })
+      callback(null, { Body: Buffer.from(content) })
     } catch (e) {
       // Treat missing fixture as 404
       callback(new NoSuchKeyError())


### PR DESCRIPTION
Hello,

As discussed, this Repo does a few things:

- Adds continuous deployment from Travis
- Remove authentication on the `GET` endpoints from the Swagger docs
- Fixes a hanging Mocha test
- Some StandardJS style fixes
- Removes the Lambda from our VPC (just a reminder, [Lambda Best Practices](https://docs.aws.amazon.com/lambda/latest/dg/best-practices.html) advises to include Lambdas in VPCs only if absolutely necessary because it increases cold-start times) 

Thanks!